### PR TITLE
Update DetallePost.html

### DIFF
--- a/cutregram/views/DetallePost.html
+++ b/cutregram/views/DetallePost.html
@@ -34,7 +34,7 @@
     <ul class="list-group">
         <li class="list-group-item" ng-repeat="comentario in post.comments">
             <p>{{ ::comentario.text }}</p>
-            <small> - {{ ::post.author | Firma:post.created }}</small>
+            <small> - {{ ::comentario.author | Firma:comentario.created }}</small>
         </li>
     </ul>
 </div>


### PR DESCRIPTION
Había un error, al copiar el filtro para  poner la firma del autor de los posts, se te olvido cambiar "post" por "comentario" por eso salía en todos los comentarios el autor del post en vez de el autor del comentario.
